### PR TITLE
feat: replace Tailwind styled buttons with shadcn/ui Button components

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { ClerkProvider, SignInButton, SignUpButton, Show, UserButton } from "@clerk/nextjs";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Button } from "@/components/ui/button";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -32,8 +33,12 @@ export default function RootLayout({
         <ClerkProvider>
           <header className="flex items-center justify-end gap-4 px-6 py-4 border-b">
             <Show when="signed-out">
-              <SignInButton mode="modal" />
-              <SignUpButton mode="modal" />
+              <SignInButton mode="modal">
+                <Button variant="outline">Sign In</Button>
+              </SignInButton>
+              <SignUpButton mode="modal">
+                <Button>Sign Up</Button>
+              </SignUpButton>
             </Show>
             <Show when="signed-in">
               <UserButton />


### PR DESCRIPTION
- Import shadcn/ui Button component in layout.tsx
- Wrap Clerk SignInButton and SignUpButton with shadcn/ui Button components
- Use 'outline' variant for Sign In button and default variant for Sign Up button
- Maintains existing modal functionality while providing consistent UI styling

Closes #5